### PR TITLE
Bugs/SESIDEV-32 opal connector timeout

### DIFF
--- a/patch/mica_distribution/modules/mica/extensions/mica_opal/includes/opal_connection.inc
+++ b/patch/mica_distribution/modules/mica/extensions/mica_opal/includes/opal_connection.inc
@@ -147,7 +147,11 @@ class MicaDatasetOpalConnectionClass extends MicaDatasetAbstractConnection imple
         }
       }
     } catch (HttpClientException $e) {
-      // ignore
+      if ($e->getCode() == 0) {
+        // Curl error
+        throw new Exception($e->getMessage());
+      }
+      // else ignore
     }
     //debug($this->fieldname_map);
   }
@@ -218,6 +222,8 @@ class MicaDatasetOpalConnectionClass extends MicaDatasetAbstractConnection imple
       CURLOPT_SSL_VERIFYPEER => FALSE,
       CURLOPT_SSLCERT => $this->realpath(PUBLIC_KEY_FILE),
       CURLOPT_SSLKEY => $this->realpath(PRIVATE_KEY_FILE),
+      CURLOPT_CONNECTTIMEOUT => 10,
+      CURLOPT_TIMEOUT => 60,
     );
 
     return $client;
@@ -228,7 +234,7 @@ class MicaDatasetOpalConnectionClass extends MicaDatasetAbstractConnection imple
 
     try {
       $result = $this->esQueryApi->query($terms);
-    } catch (Exception $e) {
+    } catch (HttpClientException $e) {
       $result = $this->esQueryDefault->query($terms);
     }
 
@@ -240,7 +246,7 @@ class MicaDatasetOpalConnectionClass extends MicaDatasetAbstractConnection imple
 
     try {
       $result = $this->esQueryApi->queryBy($terms, $fields);
-    } catch (Exception $e) {
+    } catch (HttpClientException $e) {
       $result = $this->esQueryDefault->queryBy($terms, $fields);
     }
 
@@ -252,7 +258,7 @@ class MicaDatasetOpalConnectionClass extends MicaDatasetAbstractConnection imple
 
     try {
       $result = $this->esQueryApi->crossQueryBy($terms, $fields);
-    } catch (Exception $e) {
+    } catch (HttpClientException $e) {
       $result = $this->esQueryDefault->crossQueryBy($terms, $fields);
     }
 
@@ -264,7 +270,7 @@ class MicaDatasetOpalConnectionClass extends MicaDatasetAbstractConnection imple
 
     try {
       $result = $this->esQueryApi->facetTerm($term);
-    } catch (Exception $e) {
+    } catch (HttpClientException $e) {
       $result = $this->esQueryDefault->facetTerm($term);
     }
 


### PR DESCRIPTION
Add a timeout of 10 seconds for connect and 60 seconds for the total processing (It's only summary information so shouldn't take too long). Change some exception handling so mica won't try to connect again if there's a timeout (or another curl error for that matter).
