### PR TITLE
Changed the way to retrieve the dataset_id

### DIFF
--- a/modules/query_ontologies/query_ontologies.terms.inc
+++ b/modules/query_ontologies/query_ontologies.terms.inc
@@ -131,8 +131,13 @@ class OntologyTerm extends AbstractTerm {
       '#type' => 'fieldset',
       '#title' => 'Values',
     );
-
-    $uri = "sesi/node/" . $this->qt->dataset_id . "/variable/" . $this->getVariable()->nid . "/variabletaxonomy";
+    
+    // Determine the dataset ID as it is needed to retrieve the taxonomy
+    $dataset = $form_state[ "build_info" ][ "args" ][ 0 ];
+    
+    $dataset_id = $dataset->nid;
+    
+    $uri = "sesi/node/" . $dataset_id . "/variable/" . $this->getVariable()->nid . "/variabletaxonomy";
     $taxonomyUrl = url($uri);
     $selectedIds = $this->getSelectedTermIds();
     $default_value = ''; // implode(" ", $this->match());


### PR DESCRIPTION
The old way sometimes returned 0, which led to the ontology tree not showing up.