### PR TITLE
Improved dataset inheritance

### DIFF
--- a/modules/dataset_inheritance/dataset_inheritance.module
+++ b/modules/dataset_inheritance/dataset_inheritance.module
@@ -91,10 +91,16 @@ function dataset_inheritance_node_insert($node) {
         return;
     }
 
-    $num_variables = _dataset_inheritance_clone_variables_from_parent($wrapper, $parent_nid, $wrapper->field_inherit_permissions->value());
+    $added_variable_ids = _dataset_inheritance_clone_variables_from_parent($wrapper, $parent_nid, $wrapper->field_inherit_permissions->value());
+    $num_variables = count( $added_variable_ids );
     if ( $num_variables > 0 ) {
         drupal_set_message(t("Added @entries variables.", array('@entries' => $num_variables)), 'status');
     }
+    
+    // Set reference to newly added variables in dataset object
+    // without resaving the node itself
+    $wrapper->field_dataset_variables->set( $added_variable_ids );
+    field_attach_update( 'node', $node );
     
     $search_api_index = search_api_index_load('dataset_index');
     search_api_index_items($search_api_index, -1);
@@ -317,6 +323,8 @@ function _dataset_inheritance_clone_variables_from_parent($child_dataset, $paren
 
     $result = $query->execute();
 
+    $variable_ids = array();
+    
     if (isset($result['node'])) {
         // Load parent variables
         $vars_items_nids = array_keys($result['node']);
@@ -367,13 +375,11 @@ function _dataset_inheritance_clone_variables_from_parent($child_dataset, $paren
 
             node_save($variable_node);
             
+            $variable_ids[] = $variable_node->nid;
         }
-        $entries = count($parent_variables);
-
-        return $entries;
     }
 
-    return 0;
+    return $variable_ids;
 }
 
 /**

--- a/modules/dataset_inheritance/dataset_inheritance.module
+++ b/modules/dataset_inheritance/dataset_inheritance.module
@@ -363,7 +363,7 @@ function _dataset_inheritance_clone_variables_from_parent($child_dataset, $paren
             $variable_wrapper->field_variable_inherited_flag->set( 1 );
             
             //by default publish variable
-            $variable_node->status = 1;
+            $variable_node->status = NODE_PUBLISHED;
 
             node_save($variable_node);
             


### PR DESCRIPTION
When creating a new dataset, based on a parent one (=inheritance), the newly created variables store a reference to the new dataset. However, the dataset apparenly also has a reference to the variables. This reference was not added before, which caused issues in finding the variables (e.g. they didn't appear when exporting an opal view).

This was already solved partially for SESIDEV-35 for the case when the user clicked the button 'update inheritance'