### PR TITLE
Show community owner

### DIFF
--- a/modules/features/sesi_community_hub/sesi_community_hub.pages_default.inc
+++ b/modules/features/sesi_community_hub/sesi_community_hub.pages_default.inc
@@ -253,6 +253,43 @@ function sesi_community_hub_default_page_manager_handlers() {
     $pane = new stdClass();
     $pane->pid = 'new-7';
     $pane->panel = 'left_region';
+    $pane->type = 'custom';
+    $pane->subtype = 'custom';
+    $pane->shown = TRUE;
+    $pane->access = array(
+      'plugins' => array(
+        0 => array(
+          'name' => 'role',
+          'settings' => array(
+            'rids' => array(
+              0 => 1,
+            ),
+          ),
+          'context' => 'logged-in-user',
+          'not' => TRUE,
+        ),
+      ),
+    );
+    $pane->configuration = array(
+      'admin_title' => '',
+      'title' => 'Owner',
+      'body' => '<p>%node:author</p>',
+      'format' => 'filtered_html',
+      'substitute' => 1,
+    );
+    $pane->cache = array();
+    $pane->style = array(
+      'settings' => NULL,
+    );
+    $pane->css = array();
+    $pane->extras = array();
+    $pane->position = 3;
+    $pane->locks = array();
+    $display->content['new-7'] = $pane;
+    $display->panels['left_region'][3] = 'new-7';
+    $pane = new stdClass();
+    $pane->pid = 'new-8';
+    $pane->panel = 'left_region';
     $pane->type = 'views';
     $pane->subtype = 'mica_og_members_admin';
     $pane->shown = TRUE;
@@ -295,10 +332,10 @@ function sesi_community_hub_default_page_manager_handlers() {
     );
     $pane->css = array();
     $pane->extras = array();
-    $pane->position = 3;
+    $pane->position = 4;
     $pane->locks = array();
-    $display->content['new-7'] = $pane;
-    $display->panels['left_region'][3] = 'new-7';
+    $display->content['new-8'] = $pane;
+    $display->panels['left_region'][4] = 'new-8';
   $display->hide_title = PANELS_TITLE_FIXED;
   $display->title_pane = 'new-5';
   $handler->conf['display'] = $display;

--- a/modules/features/sesi_community_hub/sesi_community_hub.pages_default.inc
+++ b/modules/features/sesi_community_hub/sesi_community_hub.pages_default.inc
@@ -272,7 +272,7 @@ function sesi_community_hub_default_page_manager_handlers() {
     );
     $pane->configuration = array(
       'admin_title' => '',
-      'title' => 'Owner',
+      'title' => 'Community manager',
       'body' => '<p>%node:author</p>',
       'format' => 'filtered_html',
       'substitute' => 1,


### PR DESCRIPTION
The owner of the community is not obviously visible, which hinders usability and makes
it easy to forget that someone still owns a community who shouldn't anymore.
This change shows the community owner on the community page to logged in users.