### PR TITLE
Issues/view own unpublished

### DIFF
--- a/drupalpull.sh
+++ b/drupalpull.sh
@@ -181,6 +181,7 @@ ensure_mod sesi_og_addcontent
 ensure_mod sesi_rules
 ensure_mod sesi_variable_email
 ensure_mod sesi_wildcard_search_processor
+ensure_mod view_own_unpublished
 
 # Download Autologout module dependencies and enable it
 drush --yes dl autologout
@@ -357,5 +358,7 @@ sed -i.bak "s/version = .*$/$REPLACEMENT/g" $DRUPAL_ROOT/profiles/mica_distribut
 cd $DRUPAL_ROOT
 drush vset maintenance_mode 1
 drush cc all
+# make sure the access grants are up to date
+drush eval 'node_access_rebuild();'
 drush vset maintenance_mode 0
 

--- a/modules/view_own_published/LICENSE.txt
+++ b/modules/view_own_published/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2015 The Hyve B.V.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/modules/view_own_published/README.txt
+++ b/modules/view_own_published/README.txt
@@ -1,0 +1,15 @@
+View Own Unpublished
+--------------------
+This module makes sure that users who have 'View own unpublished content'
+permission from the node module can see their own unpublished content in
+listings and views. They should already be able to do that, but it doesn't
+always work if modules such as content_access or acl are enabled, as they
+change the default grants. See also https://www.drupal.org/node/1190096 and
+https://www.drupal.org/node/1225520
+
+Common issues
+-------------
+If for some reason this module seems not to work, try rebuilding your node
+permissions: admin/reports/status/rebuild. Note that this can take significant
+time on larger installs and it is HIGHLY recommended that you back up your site
+first.

--- a/modules/view_own_published/view_own_unpublished.info
+++ b/modules/view_own_published/view_own_unpublished.info
@@ -1,0 +1,7 @@
+name = View Own Unpublished
+description = "Show a user's own unpublished content in listings and views for users that have the 'view own unpublished content' permission"
+package = "Permissions"
+version = 7.x-1.0-beta
+core = 7.x
+project = "view_own_unpublished"
+

--- a/modules/view_own_published/view_own_unpublished.install
+++ b/modules/view_own_published/view_own_unpublished.install
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @file view_own_unpublished.install
+ * Contains install and update functions for view_own_unpublished.
+ */
+
+/**
+ * Implements hook_enable().
+ */
+function view_own_unpublished_enable() {
+  node_access_needs_rebuild(TRUE);
+}
+
+/**
+ * Implements hook_disable().
+ */
+function view_own_unpublished_disable() {
+  node_access_needs_rebuild(TRUE);
+}

--- a/modules/view_own_published/view_own_unpublished.module
+++ b/modules/view_own_published/view_own_unpublished.module
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @file
+ * Main functions and hook implementations of the View Own Unpublished module.
+ */
+
+/**
+ * Implements hook_node_access_records().
+ */
+function view_own_unpublished_node_access_records($node) {
+  // We only care about the node if is unpublished. If not, ignore it.
+  $grants = array();
+  if ($node->status == 0) {
+    $grants[] = array(
+      'realm' => 'view_own_unpublished',
+      'gid' => $node->uid,
+      'grant_view' => 1,
+      'grant_update' => 0,
+      'grant_delete' => 0,
+      'priority' => 0,
+    );
+  }
+  return $grants;
+}
+
+/**
+ * Implements hook_node_grants().
+ */
+function view_own_unpublished_node_grants($account, $op) {
+  $grants = array();
+  if (user_access('view own unpublished content', $account)) {
+    $grants['view_own_unpublished'] = array($account->uid);
+  }
+  return $grants;
+}

--- a/seldrush.py
+++ b/seldrush.py
@@ -98,6 +98,16 @@ class Drush(SeleniumBase):
         self.passwd = passwd
     
     def changePermissions(self):
+        self.sd.get(self.base_url + "/?q=admin/people/permissions")
+
+        # Remove 'view all unpublished content' for everyone except system administrator
+        for i in [1,2,4,5,6,7,8,9,10]:
+            chkbox = self.css("#edit-%s-view-all-unpublished-content" % i)
+            self.setcheckbox(chkbox, False)
+
+        self.clickon('#edit-submit')
+
+
         self.sd.get(self.base_url + "/?q=admin/people/permissions/2")
 
         #change permissions for authenticated user


### PR DESCRIPTION
Fix for LP-64, LP-65 and LP-66

The view_own_unpublished module makes sure that users who have 'View own unpublished content' permission from the node module can see their own
unpublished content in listings and views. They should be able to do that, but it doesn't always work if modules such as content_access or acl
are enabled, as they change the default grants. See also https://www.drupal.org/node/1190096 and https://www.drupal.org/node/1225520

Compared to the previously tested Mica version there is one difference remaining: users are not able to see draft populations and data collection events etc. that they did not create, even if they are in the same community. This is because populations and DCEs are not community content.