### PR TITLE
re-enable Node as a search module

### DIFF
--- a/modules/features/sesi_filter_search/sesi_filter_search.strongarm.inc
+++ b/modules/features/sesi_filter_search/sesi_filter_search.strongarm.inc
@@ -15,11 +15,10 @@ function sesi_filter_search_strongarm() {
   $strongarm->api_version = 1;
   $strongarm->name = 'search_active_modules';
   $strongarm->value = array(
+    'node' => 'node',
     'og_filter_search' => 'og_filter_search',
     'user' => 'user',
     'advanced_help' => 0,
-    'ds_search' => 0,
-    'node' => 0,
   );
   $export['search_active_modules'] = $strongarm;
 


### PR DESCRIPTION
OG Filter Search is actually not a complete search implementation, but overrides Node's search execution to provide filtering based on OG membership. OG Filter Search does not provide its own indexing but relies on that of Node. Enabling Node as a search module should not open a security hole since OG filter search overrides Node's search implementation and hides Node search from the search page.

This is part of fixing USESI-303